### PR TITLE
allow for nested if control statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,61 +3,15 @@ var utils = require('jstransform/src/utils');
 var _ = require('lodash');
 var Syntax = jstransform.Syntax;
 var xjsElementDepth = 0;
-
-function visitIfTag(traverse, object, path, state) {
-  var attributes = object.openingElement.attributes;
-  
-  if (!attributes || !attributes.length) {
-    throwNoConditionAttr();
-  }
-  
-  var condition = _.find(attributes, function (attr) {
-    return attr.name.name === 'condition'
-  });
-  
-  if (!condition) {
-    throwNoConditionAttr();
-  }
-
-  if (insideXjsElement()) {
-    utils.append('{ ', state);
-  }
-  utils.move(condition.value.expression.range[0], state);
-  utils.catchup(condition.value.expression.range[1], state);
-  utils.append(' ? (', state);
-  utils.move(object.openingElement.range[1], state);
-  
-  var hasElse = object.children.some(function (child) {
-    if (child.type === 'XJSElement' && child.openingElement.name.name === 'Else') {
-      utils.catchup(child.range[0], state);
-      utils.append(') : (', state);
-      utils.move(child.range[1], state);
-      
-      return true;
-    }
-    
-    return false;
-  });
-  
-  utils.catchup(object.closingElement.range[0], state);
-  utils.append(hasElse ? ')' : ') : \'\'', state);
-  if (insideXjsElement()) {
-    utils.append(' }', state);
-  }
-  utils.move(object.closingElement.range[1], state);
-}
+var ifElseOpeners = [];
 
 function throwNoConditionAttr() {
-  throw new Error("<If> tag with no condition attribute")
+  throw new Error("<If> tag with no condition attribute");
 }
 
 function insideXjsElement() {
   return xjsElementDepth > 0;
 }
-
-visitIfTag.test = function (object, path, state) {
-  return object.type === 'XJSElement' && object.openingElement.name.name === 'If';
-};
 
 function visitForTag(traverse, object, path, state) {
   var attributes = object.openingElement.attributes;
@@ -103,22 +57,86 @@ visitForTag.test = function (object, path, state) {
   return object.type === 'XJSElement' && object.openingElement.name.name === 'For';
 };
 
-function keepTrack (traverse, object, path, state) {
-  if (object.type === 'XJSOpeningElement' && !object.selfClosing) {
-    xjsElementDepth++;
-  } else if (object.type === 'XJSClosingElement') {
-    xjsElementDepth--
+function visitIfOpeningElement(traverse, object, path, state) {
+  var attributes = object.attributes;
+
+  if (!attributes || !attributes.length) {
+    throwNoConditionAttr();
   }
+
+  var condition = _.find(attributes, function (attr) {
+    return attr.name.name === 'condition';
+  });
+
+  if (!condition) {
+    throwNoConditionAttr();
+  }
+
+  if (insideXjsElement()) {
+    utils.append('{', state);
+  }
+
+  utils.append('(', state);
+  utils.move(condition.value.expression.range[0], state);
+  utils.catchup(condition.value.expression.range[1], state);
+  utils.append(') ', state);
+
+  if (_.contains(ifElseOpeners, object.range[0])) {
+    utils.append('? (', state);
+  }
+  else {
+    utils.append('&& (', state);
+  }
+  utils.move(object.range[1], state);
+}
+
+visitIfOpeningElement.test = function(object, path, state) {
+  if (object.type === 'XJSElement' && object.openingElement.name.name === 'If') {
+    if (object.children.some(visitElseElement.test)) {
+      ifElseOpeners.push(object.openingElement.range[0]);
+    }
+  }
+  return object.type === 'XJSOpeningElement' && object.name.name === 'If';
+};
+
+function visitIfClosingElement(traverse, object, path, state) {
+  utils.append(')', state);
+  if (insideXjsElement()) {
+    utils.append('}', state);
+  }
+  utils.move(object.range[1], state);
+}
+
+visitIfClosingElement.test = function(object, path, state) {
+  return object.type === 'XJSClosingElement' && object.name.name === 'If';
+};
+
+function visitElseElement(traverse, object, path, state) {
+  utils.append(') : (', state);
+  utils.move(object.range[1], state);
+}
+
+visitElseElement.test = function(object, path, state) {
+  return object.type === 'XJSElement' && object.openingElement.name.name === 'Else';
+};
+
+function keepTrack (traverse, object, path, state) {
+  // noop
 }
 
 keepTrack.test = function(object, path, state) {
-  return object.type === 'XJSOpeningElement' || object.type === 'XJSClosingElement'
-}
+  if (object.type === 'XJSOpeningElement' && !object.selfClosing) {
+    xjsElementDepth++;
+  } else if (object.type === 'XJSClosingElement') {
+    xjsElementDepth--;
+  }
+  return false;
+};
 
 function throwNoEachAttr() {
-  throw new Error('<For> tag with no \'each\' or \'of\' attribute')
+  throw new Error('<For> tag with no \'each\' or \'of\' attribute');
 }
 
 module.exports = {
-  visitorList: [keepTrack, visitIfTag, visitForTag]
+  visitorList: [keepTrack, visitIfOpeningElement, visitIfClosingElement, visitElseElement, visitForTag]
 };


### PR DESCRIPTION
This keeps track of which `If` statements contain an `Else` clause and writes them differently.

`<If condition={1}><p>foo</p></If>` --> `{(1) && (<p>hi</p>)}`
`<If condition={2}><p>bar</p><Else /><p>baz</p></If>` --> `{(2) ? (<p>bar</p>) : (<p>baz</p>)}`

Because the opening and closing elements are now transformed separately, this is made possible:

```
<If condition={3}>
  <p>foo</p>
  <If condition={4}>
    <p>bar</p>
  </If>
</If>
```

becomes...

```
{(3) && (
  <p>foo</p>
  {(4) && (
    <p>bar</p>
  )}
)}
```

The parenthesis might be pedantic and may be removed.
