### PR TITLE
Add $index to For tag

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -97,7 +97,10 @@ module.exports = function (babel) {
         [
           t.functionExpression(
             null,
-            [t.identifier(each.value.value)],
+            [
+              t.identifier(each.value.value), 
+              t.identifier('$index')
+            ],
             t.blockStatement([
               t.returnStatement(child)
             ])

--- a/jstransform.js
+++ b/jstransform.js
@@ -119,7 +119,7 @@ function visitStartForTag(traverse, object, path, state) {
   utils.append('.map(function(', state);
   utils.move(each.value.range[0] + 1, state);
   utils.catchup(each.value.range[1] - 1, state);
-  utils.append(') { return (', state);
+  utils.append(', $index) { return (', state);
 
   utils.move(object.range[1], state)
   inControlStatement = true;


### PR DESCRIPTION
This change will allow you to write constructions like that:

```
<For each="rule" of={this.state.rules.categories}>
	<Rule 
		name={rule.name} 
		type="category" 
		key={$index} />
</For>
```
Yes, you can use anything else as `key` in arrays, but I think it would be neat to use built-in `map()`'s indexes. The name `$index` is inspired by angular's ng-repeat and is unlikely to collide with existing variables. 

Currently you can achieve the same result with the following code:
```
<For each="rule, $index" of={this.state.rules.categories}>
	<Rule 
		name={rule.name} 
		type="category" 
		key={$index} />
</For>
```
But it's hackish and doesn't look very good.