### PR TITLE
Add explicit index declaration in <For /> tag

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -30,7 +30,7 @@ module.exports = function (babel) {
     }
 
     var condition = _.find(attributes, function (attr) {
-      return attr.name.name === 'condition'
+      return attr.name.name === 'condition';
     });
 
     if (!condition) {
@@ -40,7 +40,7 @@ module.exports = function (babel) {
     var children = removeLiterals(node.children);
 
     var notElseTag = function (child) {
-      return child.type !== 'JSXElement' || child.openingElement.name.name !== 'Else'
+      return child.type !== 'JSXElement' || child.openingElement.name.name !== 'Else';
     };
 
     var ifBlock, elseBlock;
@@ -68,12 +68,14 @@ module.exports = function (babel) {
       throwError(errors.FOR_WITH_NO_ATTRIBUTES, node, file);
     }
 
-    var each, of;
+    var each, of, index;
     attributes.forEach(function (attr) {
       if (attr.name.name === 'each') {
         each = attr;
       } else if (attr.name.name === 'of') {
         of = attr;
+      } else if (attr.name.name === 'index') {
+        index = attr;
       }
     });
 
@@ -90,6 +92,12 @@ module.exports = function (babel) {
 
     var child = children[0];
 
+    var mapParams = [t.identifier(each.value.value)];
+
+    if (index) {
+      mapParams.push(t.identifier(index.value.value));
+    }
+
     return t.memberExpression(
       of.value.expression,
       t.callExpression(
@@ -97,7 +105,7 @@ module.exports = function (babel) {
         [
           t.functionExpression(
             null,
-            [t.identifier(each.value.value)],
+            mapParams,
             t.blockStatement([
               t.returnStatement(child)
             ])

--- a/jstransform.js
+++ b/jstransform.js
@@ -98,12 +98,14 @@ function visitStartForTag(traverse, object, path, state) {
     throw new Error(errors.FOR_WITH_NO_ATTRIBUTES);
   }
 
-  var each, of;
+  var each, of, index;
   attributes.forEach(function (attr) {
     if (attr.name.name === 'each') {
       each = attr;
     } else if (attr.name.name === 'of') {
       of = attr;
+    } else if (attr.name.name === 'index') {
+      index = attr;
     }
   });
 
@@ -119,6 +121,10 @@ function visitStartForTag(traverse, object, path, state) {
   utils.append('.map(function(', state);
   utils.move(each.value.range[0] + 1, state);
   utils.catchup(each.value.range[1] - 1, state);
+
+  if (index) {
+    utils.append(', ' + index.value.value, state);
+  }
   utils.append(') { return (', state);
 
   utils.move(object.range[1], state)

--- a/spec/fixtures/for-with-index.jsx
+++ b/spec/fixtures/for-with-index.jsx
@@ -1,0 +1,15 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  render: function () {
+    this.test = 'test';
+
+    return (
+      <div>
+        <For each="blah" index="$index" of={this.props.blahs}>
+          <span key={blah}>{blah + this.test + $index}</span>
+        </For>
+      </div>
+    );
+  }
+});

--- a/spec/fixtures/nested-for-with-indexes.jsx
+++ b/spec/fixtures/nested-for-with-indexes.jsx
@@ -1,0 +1,15 @@
+var React = require('react');
+
+module.exports = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <For each="otherBlah" index="$index1" of={this.props.otherBlahs}>
+          <For each="blah" index="$index2" of={this.props.blahs}>
+            <span key={otherBlah + blah}>{otherBlah + blah + $index1 + $index2}</span>
+          </For>
+        </For>
+      </div>
+    );
+  }
+});

--- a/spec/fixtures/nested-for-with-indexes.jsx
+++ b/spec/fixtures/nested-for-with-indexes.jsx
@@ -6,7 +6,7 @@ module.exports = React.createClass({
       <div>
         <For each="otherBlah" index="$index1" of={this.props.otherBlahs}>
           <For each="blah" index="$index2" of={this.props.blahs}>
-            <span key={otherBlah + blah}>{otherBlah + blah + $index1 + $index2}</span>
+            <span key={otherBlah + blah}>{otherBlah + blah + $index2 + $index1}</span>
           </For>
         </For>
       </div>

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -183,15 +183,15 @@ describe('requiring in component with for with index', function () {
         test: true
       });
       var rendered = React.renderToString(forInsideFor);
-      expect(rendered).to.contain('1hlabblah111');
-      expect(rendered).to.contain('1hlabblah212');
-      expect(rendered).to.contain('1hlabblah313');
-      expect(rendered).to.contain('2hlabblah121');
-      expect(rendered).to.contain('2hlabblah222');
-      expect(rendered).to.contain('2hlabblah323');
-      expect(rendered).to.contain('3hlabblah131');
-      expect(rendered).to.contain('3hlabblah232');
-      expect(rendered).to.contain('3hlabblah333');
+      expect(rendered).to.contain('1hlabblah100');
+      expect(rendered).to.contain('1hlabblah210');
+      expect(rendered).to.contain('1hlabblah320');
+      expect(rendered).to.contain('2hlabblah101');
+      expect(rendered).to.contain('2hlabblah211');
+      expect(rendered).to.contain('2hlabblah321');
+      expect(rendered).to.contain('3hlabblah102');
+      expect(rendered).to.contain('3hlabblah212');
+      expect(rendered).to.contain('3hlabblah322');
     });
   });
 

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -93,6 +93,23 @@ module.exports = function () {
     }
   });
 
+describe('requiring in component with for with index', function () {
+  var ForWithIndex = require('./fixtures/for-with-index.jsx');
+ 
+  it('should render list of items', function () {
+    var forAsRoot = React.createElement(ForWithIndex, {blahs: ['blah1', 'blah2', 'blah3']});
+    var rendered = React.renderToString(forAsRoot);
+    expect(rendered).to.match(/.*span.*blah1test0..*span.*span.*blah2test1.*span.*blah3test2.*span.*/);
+  });
+
+  it('should render empty list of items as blank', function () {
+    var forAsRoot = React.createElement(ForWithIndex, {blahs: []});
+    var rendered = React.renderToString(forAsRoot);
+    expect(rendered).to.match(/<div.*><\/div>/);
+  });
+  
+});
+
   describe('nesting if within for', function () {
     var IfInsideFor = require('./fixtures/if-inside-for.jsx');
 
@@ -153,6 +170,28 @@ module.exports = function () {
       expect(rendered).to.contain('3hlabblah1');
       expect(rendered).to.contain('3hlabblah2');
       expect(rendered).to.contain('3hlabblah3');
+    });
+  });
+
+  describe('nesting for within for with indexes', function () {
+    var ForInsideFor = require('./fixtures/nested-for-with-indexes.jsx');
+
+    it('should render a list of items using indexes from both Fors', function () {
+      var forInsideFor = React.createElement(ForInsideFor, {
+        blahs: ['blah1', 'blah2', 'blah3'],
+        otherBlahs: ['1hlab', '2hlab', '3hlab'],
+        test: true
+      });
+      var rendered = React.renderToString(forInsideFor);
+      expect(rendered).to.contain('1hlabblah111');
+      expect(rendered).to.contain('1hlabblah212');
+      expect(rendered).to.contain('1hlabblah313');
+      expect(rendered).to.contain('2hlabblah121');
+      expect(rendered).to.contain('2hlabblah222');
+      expect(rendered).to.contain('2hlabblah323');
+      expect(rendered).to.contain('3hlabblah131');
+      expect(rendered).to.contain('3hlabblah232');
+      expect(rendered).to.contain('3hlabblah333');
     });
   });
 


### PR DESCRIPTION
Implements a proposal that was discussed in #8 
This change will allow to use structures like: 
`<For each="cat" index="$index" of={this.state.categories}>`
Which will be compiled to:
`this.state.categories.map(function(cat, $index){ ... }) `